### PR TITLE
APP-4960: enforce --frozen-lockfile and add Aikido Safe Chain v1.4.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,13 @@ RUN pip install --quiet --no-cache-dir awscli==${AWSCLI_VERSION} --break-system-
 RUN npm i -g --force yarn
 
 # Install Aikido Safe Chain v1.4.9 for supply chain protection
+# Use a system-wide install dir so it's accessible to USER node
 RUN apk add --no-cache curl && \
-    curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.4.9/install-safe-chain.sh | sh -s -- --ci && \
+    curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.4.9/install-safe-chain.sh | sh -s -- --ci --install-dir /usr/local/.safe-chain && \
     apk del curl
-RUN mkdir -p /root/.safe-chain && \
-    printf '{"minimumPackageAgeHours":720,"npm":{"minimumPackageAgeExclusions":["@thecloudconnectors/*"]}}\n' > /root/.safe-chain/config.json
-ENV PATH="/root/.safe-chain/shims:/root/.safe-chain/bin:${PATH}"
+RUN mkdir -p /usr/local/.safe-chain && \
+    printf '{"minimumPackageAgeHours":720,"npm":{"minimumPackageAgeExclusions":["@thecloudconnectors/*"]}}\n' > /usr/local/.safe-chain/config.json
+ENV PATH="/usr/local/.safe-chain/shims:/usr/local/.safe-chain/bin:${PATH}"
 ENV SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=720
 ENV SAFE_CHAIN_LOGGING=silent
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ RUN pip install --quiet --no-cache-dir awscli==${AWSCLI_VERSION} --break-system-
 
 RUN npm i -g --force yarn
 
-# Install Aikido Safe Chain v1.4.7 for supply chain protection
+# Install Aikido Safe Chain v1.4.9 for supply chain protection
 RUN apk add --no-cache curl && \
-    curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.4.7/install-safe-chain.sh | sh -s -- --ci && \
+    curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.4.9/install-safe-chain.sh | sh -s -- --ci && \
     apk del curl
 ENV PATH="/root/.safe-chain/shims:/root/.safe-chain/bin:${PATH}"
 ENV SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=48

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,14 @@ RUN pip install --quiet --no-cache-dir awscli==${AWSCLI_VERSION} --break-system-
 
 RUN npm i -g --force yarn
 
+# Install Aikido Safe Chain v1.4.7 for supply chain protection
+RUN apk add --no-cache curl && \
+    curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.4.7/install-safe-chain.sh | sh -s -- --ci && \
+    apk del curl
+ENV PATH="/root/.safe-chain/shims:/root/.safe-chain/bin:${PATH}"
+ENV SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=48
+ENV SAFE_CHAIN_LOGGING=silent
+
 COPY entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,10 @@ RUN npm i -g --force yarn
 RUN apk add --no-cache curl && \
     curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.4.9/install-safe-chain.sh | sh -s -- --ci && \
     apk del curl
+RUN mkdir -p /root/.safe-chain && \
+    printf '{"minimumPackageAgeHours":720,"npm":{"minimumPackageAgeExclusions":["@thecloudconnectors/*"]}}\n' > /root/.safe-chain/config.json
 ENV PATH="/root/.safe-chain/shims:/root/.safe-chain/bin:${PATH}"
-ENV SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=48
+ENV SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=720
 ENV SAFE_CHAIN_LOGGING=silent
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Fixes [APP-4960](https://thecloudconnectors.atlassian.net/browse/APP-4960)

- `entrypoint.sh`: add `--frozen-lockfile` when cmd is `install` (covers 12 repos)
- `Dockerfile`: install Aikido Safe Chain v1.4.7 to intercept all `yarn install` calls with malware scanning and 48h package age filter

[APP-4960]: https://thecloudconnectors.atlassian.net/browse/APP-4960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ